### PR TITLE
Update API provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ We are a company based in Munich, Germany and are expanding internationally to t
 
 ## the data
 
-Please use https://currencylayer.com/ to retrieve raw currency data, and please utilize the client library provided here: (https://www.npmjs.com/package/currencylayer-client). 
-
-PS: Free tier comes with limited number of requests and features (only [/historical](https://currencylayer.com/documentation#historical_rates) endpoint can be used)
+Please use https://openexchangerates.org/ to retrieve raw currency rates.
+You may simply consume the web service or use the client library provided here: https://www.npmjs.com/package/open-exchange-rates. 
+free Sign up for free tier https://openexchangerates.org/signup/free.
 
 ## requirements
 


### PR DESCRIPTION
Current challenge suggests the use of https://currencylayer.com/.

The free tier, since the beginning had some limitations which added complexity to the challenge but they were welcome as they can showcase how candidates can bypass these problems.
- Base currency is limited to `USD`: calculation needed to convert from `USD` to `GBP` for example,
- Request limit 250 requests / month : some candidates went the extra mile and implemented caching solutions to get around this

Recently currencylayer downgraded their free tier more and removed ability to use `/convert` endpoint  which by default responds with current conversion rates for the given `from` and `to` currency. To do the same now you have to use `/historical` endpoint and provide `date=${todayDate}` which was confusing for some candidates.

Therefor i search some other free solutions i and stumbled upon https://openexchangerates.org/.

In term of limitation they are somehow similar 
- Request limit 1000 requests / month
- Base currency is limited USD (but NPM package code examples demonstrate how to convert between any two currencies)
- has an official [NPM package](https://www.npmjs.com/package/open-exchange-rates), seems like a beta version it works but limited to `/latest` and `/historical` (does not implements all available API features)
- Limited supported currencies compared to currencylayer (but that's no an issue)

Overall OpenExchangeRates feel less restrictive and can make the challenge easier

If you know any alternative feel free to suggest